### PR TITLE
Enforce explicit approval for default Slack identity fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# slack-messenger Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2025-10-22
+
+## Active Technologies
+- TypeScript 5.3+ on Node.js 22 + `@slack/web-api`, `commander`, `js-yaml`, `vitest` (006-config-post-identity-plan)
+
+## Project Structure
+```
+src/
+tests/
+```
+
+## Commands
+npm test && npm run lint
+
+## Code Style
+TypeScript 5.3+ on Node.js 22: Follow standard conventions
+
+## Recent Changes
+- 006-config-post-identity-plan: Added TypeScript 5.3+ on Node.js 22 + `@slack/web-api`, `commander`, `js-yaml`, `vitest`
+
+<!-- MANUAL ADDITIONS START -->
+<!-- MANUAL ADDITIONS END -->

--- a/channels.yaml
+++ b/channels.yaml
@@ -1,3 +1,7 @@
+sender_identity:
+  name: 'Release Notifier'
+  icon_emoji: ':rocket:'
+
 channel_lists:
   - name: 'test'
     description: 'Channels for development team'

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -1,0 +1,132 @@
+# `channels.yaml` Configuration Schema
+
+This document explains the expected structure for the `channels.yaml` file that powers the CLI commands in this project (`broadcast`, `send-message`, and `list-channels`). The same schema applies when you point the CLI at an alternate file via `--config`.
+
+> **Scope.** The loader accepts both snake_case and camelCase key names for certain sections, but snake_case is preferred throughout this document.
+
+## Root Object
+
+The root of the YAML file must be a map (object) with the keys below. Unknown keys are ignored, but the required structure must be present.
+
+| Key               | Required | Type                      | Notes                                                                                                          |
+| ----------------- | -------- | ------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `channel_lists`   | ✅       | array of objects          | Must contain at least one list definition. This is the only required top-level section.                        |
+| `mentions`        | ➖       | map<string, MentionEntry> | Provides placeholder → mention mappings reused across all messages.                                            |
+| `sender_identity` | ➖       | object                    | Optional default sender profile applied to Slack API calls. CamelCase alias `senderIdentity` is also accepted. |
+
+## `channel_lists` (required)
+
+Each entry describes a named bundle of channels that can be broadcast to. The CLI resolves a list by its `name`.
+
+| Field         | Required | Type          | Notes                                                                                                    |
+| ------------- | -------- | ------------- | -------------------------------------------------------------------------------------------------------- |
+| `name`        | ✅       | string        | Non-empty, unique across the file. Trimmed; duplicates raise an error.                                   |
+| `channels`    | ✅       | array<string> | 1–100 entries. Each entry is validated and deduplicated within the list.                                 |
+| `description` | ➖       | string        | Optional freeform description for human readers. Currently ignored by the CLI but preserved for tooling. |
+
+### Channel identifiers
+
+Every item in `channels` must be either a channel ID or a channel name:
+
+- **Channel ID**: Matches the regex $^C[A-Z0-9]{10}$ (case-insensitive when authoring; internally upper-cased). Example: `C1234567890`.
+- **Channel name**: Begins with `#` followed by lowercase letters, digits, hyphens, or underscores (`^[a-z0-9\-_]+$`). Example: `#engineering-alerts`.
+
+If a channel fails validation, loading the configuration throws an error. Duplicate identifiers inside the same list are also rejected. Different lists may reference the same channel.
+
+## `mentions` (optional)
+
+Defines reusable mention placeholders. Keys are the placeholder tokens (case-sensitive). Values support either the full object form or a shorthand string.
+
+```yaml
+mentions:
+  alice:
+    id: U111AAA
+    type: user
+  platform-team:
+    id: S222TEAM
+    type: team
+  legacy-user: U333LEGACY # shorthand → treated as { id: 'U333LEGACY', type: 'user' }
+```
+
+| Field  | Required | Type               | Notes                                                                                              |
+| ------ | -------- | ------------------ | -------------------------------------------------------------------------------------------------- |
+| `id`   | ✅       | string             | Slack user, subteam (a.k.a. user group), or other special identifier. Trimmed; must be non-empty.  |
+| `type` | ➖       | `'user' \| 'team'` | Defaults to `'user'`. `'team'` produces `<!subteam^{id}>`. Unknown values are coerced to `'user'`. |
+
+Additional rules:
+
+- Placeholder lookups are exact-match and case-sensitive.
+- Duplicate keys are allowed; the last definition wins.
+- Shorthand string values (plain `id`) are supported for backward compatibility.
+- Placeholders support both `@{name}` and `@name` (followed by a space or end-of-line) in message text. Unmapped placeholders are left unchanged.
+- Built-in `@here` and `@{here}` always resolve to `<!here>` and are counted under the key `here`.
+
+## `sender_identity` (optional)
+
+Controls the default display name and icon used when the CLI posts messages. Both snake_case and camelCase field names are accepted; snake_case preferred below.
+
+| Field                    | Required | Type    | Notes                                                                                                                                    |
+| ------------------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                   | ✅\*     | string  | Required when the section is present. Trimmed, must be non-empty.                                                                        |
+| `icon_emoji`             | ✅\*     | string  | Slack emoji shortcode (e.g. `:rocket:`). Mutually exclusive with `icon_url`. Alias: `iconEmoji`.                                         |
+| `icon_url`               | ✅\*     | string  | HTTPS image URL used as avatar. Alias: `iconUrl`.                                                                                        |
+| `icon`                   | ➖       | string  | Legacy alias for `icon_emoji`. If it matches `:shortcode:`, it is mapped automatically.                                                  |
+| `allow_default_identity` | ➖       | boolean | When `true`, the CLI may fall back to Slack’s default bot identity if overrides strip both name and icon. Alias: `allowDefaultIdentity`. |
+
+\*At least one icon field (`icon_emoji` or `icon_url`) must be supplied alongside `name`. If both icons are omitted or both are provided, validation fails.
+
+CLI flags (`--sender-name`, `--sender-icon-emoji`, `--sender-icon-url`) override these fields. When overrides specify an emoji, any configured URL is cleared (and vice versa).
+
+## Validation Summary
+
+- The root document must be a single YAML object.
+- `channel_lists` must exist, must be an array, and cannot be empty.
+- Each list name is trimmed, non-empty, unique, and cannot exceed 100 channels.
+- Channel identifiers are trimmed; IDs are upper-cased; names must stay lowercase.
+- `mentions` (if present) must be a mapping whose values are objects or strings. Every entry must resolve to a non-empty `id`.
+- `sender_identity` (if present) must supply `name` and exactly one icon field; optional `allow_default_identity` must be boolean.
+
+Any rule violation causes the loader to throw, and downstream CLI commands surface the validation message to the user.
+
+## Examples
+
+### Minimal configuration
+
+```yaml
+channel_lists:
+  - name: 'alerts'
+    channels:
+      - C1234567890
+```
+
+### Full configuration with mentions and identity
+
+```yaml
+sender_identity:
+  name: 'Release Notifier'
+  icon_emoji: ':rocket:'
+
+mentions:
+  takezoux2:
+    id: U05S5GBRSSV
+  leaders:
+    id: S06EP3W9NQ1
+    type: team
+
+channel_lists:
+  - name: 'test'
+    description: 'Channels for development team'
+    channels:
+      - C09HERT8BFA
+      - C09GFMCJSLT
+  - name: 'prod-alerts'
+    channels:
+      - '#prod-incidents'
+      - '#oncall'
+```
+
+## Operational Notes
+
+- The CLI caches parsed configurations per file path and reloads only when the file’s modification time changes.
+- Use `slack-messenger list-channels --config <path>` to verify that your file parses correctly; validation errors will surface immediately.
+- Tests under `tests/integration` cover additional edge cases such as empty lists, invalid channels, and mention resolution. Consult them when extending the schema.

--- a/specs/006-config-post-identity/checklists/requirements.md
+++ b/specs/006-config-post-identity/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Config-based Posting Identity
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-10-22
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Checklist completed after validating the specification against each item.
+

--- a/specs/006-config-post-identity/contracts/sender-identity.schema.yaml
+++ b/specs/006-config-post-identity/contracts/sender-identity.schema.yaml
@@ -1,0 +1,48 @@
+# Sender Identity Configuration Schema (informational)
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Slack Messenger Sender Identity
+description: Configuration block that drives the CLI display name and icon when posting to Slack.
+type: object
+required:
+  - sender_identity
+properties:
+  sender_identity:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+        minLength: 1
+        description: Display name to present in Slack messages.
+      icon_emoji:
+        type: string
+        pattern: ^:[a-z0-9_+-]+:$
+        description: Slack emoji shortcode (e.g., :bell:).
+      icon_url:
+        type: string
+        format: uri
+        description: HTTPS URL to an icon image sized per Slack guidance (72x72 recommended).
+      icon:
+        type: string
+        description: Legacy shorthand; treated as icon_emoji when it matches shortcode format.
+    allOf:
+      - if:
+          properties:
+            icon_emoji:
+              type: string
+        then:
+          not:
+            required:
+              - icon_url
+        else:
+          if:
+            properties:
+              icon_url:
+                type: string
+            then:
+              not:
+                required:
+                  - icon_emoji
+    additionalProperties: false
+additionalProperties: true

--- a/specs/006-config-post-identity/data-model.md
+++ b/specs/006-config-post-identity/data-model.md
@@ -1,0 +1,39 @@
+# Data Model: Config-based Posting Identity
+
+## SenderIdentity (new)
+- **Purpose**: Represents the resolved display identity applied to any outgoing Slack message.
+- **Fields**:
+  - `displayName: string | null` — human-readable name shown in Slack. Required when sourced from configuration or CLI override.
+  - `iconEmoji: string | null` — Slack emoji shortcode (e.g., `:bell:`). Mutually exclusive with `iconUrl`.
+  - `iconUrl: string | null` — HTTPS URL pointing to the icon image. Mutually exclusive with `iconEmoji`.
+  - `source: 'config' | 'cli-override' | 'fallback-default'` — indicates where the values originated.
+  - `warnings: string[]` — captures validation or fallback notices for verbose/audit logging.
+  - `applied: boolean` — flags whether the identity was successfully forwarded to Slack (false when scope prevented customization).
+
+## ChannelConfiguration (updated)
+- **Existing fields**: `channelLists: NamedChannelList[]`, `mentions?: MentionMapping`, `filePath: string`, `lastModified?: Date`.
+- **New field**: `senderIdentity?: SenderIdentityConfig` — optional configuration block.
+  - `SenderIdentityConfig` fields:
+    - `name: string` — required, non-empty.
+    - `icon_emoji?: string` — optional emoji shortcode.
+    - `icon_url?: string` — optional HTTPS URL.
+    - `icon?: string` — legacy shorthand; treated as emoji when it matches `:shortcode:`.
+
+## CommandLineOptions (updated)
+- **New getters**: `senderName?: string`, `senderIconEmoji?: string`, `senderIconUrl?: string`, `allowDefaultIdentity?: boolean`.
+- **Validation rules**:
+  - Overrides must respect mutual exclusion between emoji and URL.
+  - CLI override values short-circuit configuration defaults.
+  - `allowDefaultIdentity` implies consent to continue without configured values.
+
+## IdentityResolutionContext (new helper structure)
+- **Inputs**: `configIdentity?: SenderIdentityConfig`, `cliOverrides`, `environment: { isInteractive: boolean }`.
+- **Outputs**: `resolved: SenderIdentity`, `needsConfirmation: boolean`.
+- **Relationships**: Consumed by both `SendMessageCommand` and `BroadcastMessageCommand` prior to Slack API calls.
+
+## SlackMessage (unchanged core)
+- **Augmentation**: Accepts optional `senderIdentity` parameter during `SlackService.sendMessage` to carry display metadata into API payload construction.
+
+## PromptConsentResult (new utility type)
+- **Fields**: `confirmed: boolean`, `reason?: string`.
+- **Usage**: Standardizes the response from the TTY-aware prompt utility so commands can uniformly enforce fallback consent.

--- a/specs/006-config-post-identity/plan.md
+++ b/specs/006-config-post-identity/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: Config-based Posting Identity
+
+**Branch**: `006-config-post-identity-plan` | **Date**: 2025-10-22 | **Spec**: [/specs/006-config-post-identity/spec.md](/specs/006-config-post-identity/spec.md)
+**Input**: Feature specification from `/specs/006-config-post-identity/spec.md`
+
+## Summary
+
+- Extend the YAML configuration schema with a `sender_identity` object (name + emoji/url icon) and validation coverage aligned with Slack's `chat.postMessage` parameters.
+- Add a reusable identity resolution service that merges CLI overrides, configuration defaults, and fallback behaviour while logging provenance for verbose/audit output.
+- Update `send-message` and `broadcast` command flows to load configuration when needed, enforce explicit confirmation before falling back to the default bot identity, and expose new CLI override flags.
+- Enhance Slack API integration to pass the resolved identity fields, report scope-related errors clearly, and keep non-interactive runs deterministic.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3+ on Node.js 22
+**Primary Dependencies**: `@slack/web-api`, `commander`, `js-yaml`, `vitest`
+**Storage**: YAML configuration files on disk (channel + sender identity metadata)
+**Testing**: Vitest unit/integration suites with existing mocking of Slack service interactions
+**Target Platform**: Node.js CLI executed in CI pipelines and operator laptops
+**Project Type**: Single-package CLI application under `src/`
+**Performance Goals**: Maintain current single API call per message; identity resolution should add <5 ms overhead locally
+**Constraints**: Must gracefully handle tokens lacking `chat:write.customize` by warning and falling back after explicit consent; confirmation UX cannot block non-interactive automation
+**Scale/Scope**: Designed for small team broadcasts (≤100 channels per list) with shared sender identity defaults
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- No ratified constitution content is provided in `.specify/memory/constitution.md`; treating constitutional gates as non-applicable. **Status: PASS**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/006-config-post-identity/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```
+src/
+├── commands/
+│   ├── broadcast-message.command.ts       # apply identity to multi-channel sends
+│   └── send-message.command.ts            # apply identity + confirmation flow
+├── config/
+│   └── app-config.ts                      # surface config loader helpers
+├── models/
+│   ├── channel-configuration.ts           # add sender identity structure
+│   ├── command-line-options.ts            # expose override fields
+│   └── sender-identity.ts                 # NEW: typed identity value object
+├── services/
+│   ├── cli.service.ts                     # register new CLI flags
+│   ├── config-validation.service.ts       # validate identity section
+│   ├── identity-resolution.service.ts     # NEW: merge config/CLI/defaults
+│   ├── slack.service.ts                   # pass username/icon to API
+│   └── yaml-config.service.ts             # parse sender identity from YAML
+└── utils/
+    └── prompt.service.ts                  # NEW: centralized confirmation helper (TTY-aware)
+
+tests/
+├── unit/
+│   ├── services/identity-resolution.service.test.ts
+│   ├── services/yaml-config.service.test.ts
+│   ├── services/config-validation.service.test.ts
+│   └── commands/send-message.command.test.ts
+└── integration/
+    └── cli-identity-flows.test.ts
+```
+
+**Structure Decision**: Retain the existing single-package CLI layout while introducing focused services (`identity-resolution`, `prompt`) and corresponding unit test suites under `tests/unit`; add an integration suite to cover end-to-end CLI identity behaviour.
+
+## Complexity Tracking
+
+*No constitutional violations identified; no additional complexity justification required.*

--- a/specs/006-config-post-identity/quickstart.md
+++ b/specs/006-config-post-identity/quickstart.md
@@ -1,0 +1,24 @@
+# Quickstart: Config-based Posting Identity
+
+1. **Update configuration**
+   - Add a `sender_identity` block to your Slack YAML configuration:
+     ```yaml
+     sender_identity:
+       name: "Notification Bot"
+       icon_emoji: ":bell:"
+     ```
+   - Commit the change alongside channel list updates so operators share the same defaults.
+
+2. **Run send-message with defaults**
+   - Execute `yarn start send-message C1234567890 "Deployment complete"`.
+   - The CLI loads the configuration, resolves the identity, and posts with the configured name and icon.
+
+3. **Override for special cases**
+   - Use `--sender-name` / `--sender-icon-emoji` or `--sender-icon-url` to override the defaults for a single run.
+   - Overrides are logged as `source=cli-override` in verbose mode.
+
+4. **Handle missing identity**
+   - If the configuration lacks name or icon, the CLI prompts for confirmation (TTY) or requires `--allow-default-identity` in scripts before falling back to the default Slack bot appearance.
+
+5. **Verify delivery**
+   - Run with `--verbose` to see which identity was applied and whether Slack accepted the customization (scope errors downgrade to the default identity with a warning).

--- a/specs/006-config-post-identity/research.md
+++ b/specs/006-config-post-identity/research.md
@@ -1,0 +1,16 @@
+# Research Findings: Config-based Posting Identity
+
+## Slack display identity customization
+- **Decision**: Use Slack `chat.postMessage` parameters (`username`, `icon_emoji`, `icon_url`) when the token includes the `chat:write.customize` scope, and fall back to the bot's default identity when the scope is absent.
+- **Rationale**: Slack's Web API allows overriding the displayed sender name and icon through these optional fields for workspace apps with the customize scope. Attempting to set them without the scope yields `invalid_arguments`, so the CLI must detect this failure and report it without blocking message delivery.
+- **Alternatives considered**: (1) Using legacy incoming webhooks—rejected because the CLI already depends on bot tokens. (2) Creating a custom Slack app per identity—rejected as it multiplies operational overhead.
+
+## Configuration schema for sender identity
+- **Decision**: Extend the YAML configuration with a top-level `sender_identity` object containing `name` plus either `icon_emoji` or `icon_url`, keeping optional legacy shorthand `icon` that maps to `icon_emoji` when it matches `:shortcode:` syntax.
+- **Rationale**: This structure mirrors Slack's parameter model and keeps validation straightforward. Supporting a legacy `icon` field preserves user expectations from the specification while guiding teams toward explicit emoji vs. URL fields.
+- **Alternatives considered**: (1) Allowing free-form `icon` strings and attempting automatic detection at runtime—rejected for increasing runtime failure risk. (2) Embedding identity inside each channel list—rejected because the feature scope defines a single shared identity.
+
+## Non-interactive confirmation strategy
+- **Decision**: Require explicit operator consent before using the default Slack identity by prompting interactively when `stdin` is a TTY, and falling back to a `--allow-default-identity` flag (or an explicit override via CLI flags) for non-interactive contexts.
+- **Rationale**: Interactive confirmation satisfies the requirement for human acknowledgement while the flag keeps automation pipelines unblocked. Treating CLI overrides as consent ensures operators can bypass the prompt when they intentionally set custom identity values.
+- **Alternatives considered**: (1) Always failing when identity is incomplete—rejected because it adds friction for emergency use. (2) Automatically proceeding with warnings—rejected as it violates the requirement for explicit confirmation.

--- a/specs/006-config-post-identity/spec.md
+++ b/specs/006-config-post-identity/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: Config-based Posting Identity
+
+**Feature Branch**: `006-config-post-identity`
+**Created**: 2025-10-22
+**Status**: Draft
+**Input**: User description: "投稿時に、configファイルから投稿者の名前とアイコンを取得し、その名前とアイコンで投稿できるようにして"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Post message with configured identity (Priority: P1)
+
+As a release manager running the CLI, I want each message I send to Slack to automatically show the sender name and icon defined in our shared configuration file so that recipients immediately recognize the notification source without me providing identity options every time.
+
+**Why this priority**: Ensures all standard notifications present a consistent brand identity, which is critical for trust and recognition.
+
+**Independent Test**: Execute the CLI `send-message` command using a config file that defines a sender identity and confirm the resulting Slack message displays the configured name and icon without additional command parameters.
+
+**Acceptance Scenarios**:
+
+1. **Given** the configuration file specifies `notification-bot` as the display name and a bell emoji as the icon, **When** a user sends a message via the CLI without overriding identity fields, **Then** the Slack message shows `notification-bot` with the bell icon.
+2. **Given** the configuration file provides a sender identity and Slack confirms message delivery, **When** the CLI sends a message, **Then** the audit log or verbose output indicates which identity was applied so operators can verify the configuration used.
+
+---
+
+### User Story 2 - Broadcast with shared identity (Priority: P2)
+
+As a communications specialist sending a broadcast to multiple channels, I want the CLI to apply the same configured name and icon across all targets so the announcement looks unified everywhere.
+
+**Why this priority**: Consistency across multi-channel broadcasts avoids confusion caused by different sender appearances and reduces the risk of mistaken authenticity.
+
+**Independent Test**: Run the `broadcast` command using a configuration file that defines a sender identity and verify each channel receives the message with identical display name and icon attributes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a configuration with a sender identity and a channel list named `release-alerts`, **When** a broadcast is sent, **Then** each channel in the list shows the configured name and icon.
+2. **Given** verbose mode is enabled, **When** the broadcast completes, **Then** the CLI output lists the identity applied for the broadcast to confirm consistency.
+
+---
+
+### User Story 3 - Override fallback handling (Priority: P3)
+
+As a CLI operator preparing a one-off announcement, I want the tool to tell me if the configuration lacks a sender name or icon and fall back to the default Slack identity only after explicit confirmation, so that I avoid sending unattributed or confusing alerts by mistake.
+
+**Why this priority**: Protects against misconfiguration by ensuring operators notice missing identity data before sending high-impact messages.
+
+**Independent Test**: Modify the configuration file to omit the icon value, attempt to send a message, and confirm the CLI surfaces a warning and requires confirmation or explicit override before using a fallback identity.
+
+**Acceptance Scenarios**:
+
+1. **Given** the configuration file is missing an icon value, **When** an operator runs the send command, **Then** the CLI warns that the icon is not configured and explains the fallback behavior before sending.
+2. **Given** the configuration lacks both name and icon, **When** the operator chooses to proceed after the warning, **Then** the CLI sends the message using Slack's default bot identity and logs that the default was used.
+
+---
+
+### Edge Cases
+
+- Configuration file contains multiple sender identity entries; the CLI should clearly document which section controls send-message and broadcast commands and ignore unrelated values.
+- Configuration file exists but is unreadable due to permissions; the CLI should fail fast with guidance to fix access before attempting to send.
+- Configuration provides an icon URL that Slack rejects; the CLI should surface the API error and advise the operator to update the configuration.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST read sender name and icon attributes from the designated configuration file before executing send or broadcast commands.
+- **FR-002**: The CLI MUST apply the configured sender name and icon to Slack messages for both single-channel and broadcast operations when the configuration supplies valid values.
+- **FR-003**: The CLI MUST provide a clear warning and fallback explanation when either the name or icon is missing from the configuration before sending any message.
+- **FR-004**: Operators MUST be able to override the configured identity at runtime via existing or documented CLI options, with the override taking precedence over configuration values.
+- **FR-005**: The system MUST log (in verbose output or audit logs) the resolved sender identity used for each message attempt, including whether the values came from configuration or were overridden.
+- **FR-006**: The CLI MUST validate the sender identity section of the configuration during startup or command execution and report structured errors if required fields are malformed (e.g., unsupported icon formats).
+
+### Key Entities *(include if feature involves data)*
+
+- **SenderIdentity**: Represents the display information applied to Slack messages; includes display name, icon reference (emoji short code or image URL), and metadata indicating whether values originated from configuration or runtime override.
+- **MessagingCommand**: Abstract representation of a CLI operation that sends messages (send-message, broadcast); uses SenderIdentity to assemble the final request payload for Slack and records which configuration file supplied the identity.
+- **ConfigFile**: The YAML configuration file that now includes a sender identity section alongside channel lists; stores default sender details and validation rules such as required fields and acceptable icon formats.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of messages sent via the CLI with a valid configuration display the configured sender name and icon in Slack confirmation screenshots.
+- **SC-002**: 95% of send or broadcast attempts with missing identity fields alert the operator before any network call is made, measured across test executions.
+- **SC-003**: Operator satisfaction with sender identity handling (captured via post-release feedback or survey) reaches at least 4 out of 5 for clarity and consistency.
+- **SC-004**: Support requests related to incorrect sender identity drop by 80% within one month of release compared to the previous month.
+
+## Assumptions *(optional)*
+
+- The configuration file will gain a clearly defined `sender_identity` section containing `name` and `icon` fields, and optionally support `icon_emoji` or `icon_url` values following Slack's standard semantics.
+- Operators already know how to provide runtime overrides for sender name and icon through existing CLI flags; documentation updates will reference these options alongside the new configuration defaults.
+- Slack API permissions already allow setting custom display names and icons for the bot token in use, so no additional scopes are required.
+- Configuration validation currently performed for channel lists can be extended to cover the new sender identity schema without introducing new third-party dependencies.
+
+## Out of Scope *(optional)*
+
+- Managing different sender identities per channel list; this feature focuses on a single default identity shared across commands.
+- Providing UI tools for editing the configuration file; updates remain manual via text editors or existing workflows.
+- Implementing dynamic identity selection based on message content or scheduling logic.
+

--- a/specs/006-config-post-identity/tasks.md
+++ b/specs/006-config-post-identity/tasks.md
@@ -1,0 +1,175 @@
+# Tasks: Config-based Posting Identity
+
+**Input**: Design documents from `/specs/006-config-post-identity/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare shared fixtures and examples so identity behaviour can be exercised consistently across commands and tests.
+
+- [ ] T001 Update shared configuration example with a `sender_identity` block in `channels.yaml` at repo root.
+- [ ] T002 Add default `sender_identity` values to `test-config.yml` to support identity-aware tests.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Introduce core models, parsing, and validation that all user stories require before commands can apply sender identity.
+
+- [ ] T003 Create `src/models/sender-identity.ts` defining resolved and configured sender identity types.
+- [ ] T004 Extend `src/models/channel-configuration.ts` to surface optional sender identity configuration metadata.
+- [ ] T005 [P] Add sender identity parsing logic to `src/services/yaml-config.service.ts` and persist origin details on the configuration model.
+- [ ] T006 [P] Cover sender identity parsing scenarios (emoji vs URL, legacy `icon`) in `tests/unit/services/yaml-config.service.test.ts`.
+- [ ] T007 Update `src/services/config-validation.service.ts` with schema rules and error messaging for the `sender_identity` section.
+- [ ] T008 Add validation unit tests for sender identity requirements in `tests/unit/services/config-validation.service.test.ts`.
+- [ ] T009 Introduce resolved identity metadata storage on `src/models/message-delivery-result.ts` for audit logging.
+
+**Checkpoint**: Identity data can be loaded and validated from configuration before any command logic runs.
+
+---
+
+## Phase 3: User Story 1 - Post message with configured identity (Priority: P1) 🎯 MVP
+
+**Goal**: Ensure `send-message` applies the configured identity and reports the applied values in verbose output.
+
+**Independent Test**: Run `yarn start send-message C1234567890 "Deployment complete" --config ./channels.yaml --verbose` with a configured identity and verify Slack receives the configured name/icon while verbose logs show the resolved identity source.
+
+### Tests for User Story 1
+
+- [ ] T010 [P] [US1] Add identity resolution unit coverage to `tests/unit/services/identity-resolution.service.test.ts`.
+- [ ] T011 [US1] Extend `tests/unit/commands/send-message.command.test.ts` (or create if absent) to assert configured identity is passed to SlackService with verbose logging metadata.
+
+### Implementation for User Story 1
+
+- [ ] T012 [P] [US1] Implement `src/services/identity-resolution.service.ts` to merge configuration identity data and produce provenance warnings.
+- [ ] T013 [US1] Integrate identity loading into `src/config/app-config.ts` so commands receive validated sender identity alongside channel lists.
+- [ ] T014 [US1] Update `src/commands/send-message.command.ts` to resolve sender identity, include provenance logs, and supply metadata to delivery results.
+- [ ] T015 [US1] Expand `src/services/slack.service.ts` to accept optional sender identity fields when posting messages and record Slack scope failures in metadata.
+- [ ] T016 [US1] Capture applied identity details on `src/models/message-delivery-result.ts` instances for verbose/audit output.
+
+**Checkpoint**: Single-channel sends automatically use the configured identity and provide traceability.
+
+---
+
+## Phase 4: User Story 2 - Broadcast with shared identity (Priority: P2)
+
+**Goal**: Ensure broadcasts reuse the shared sender identity across all channels with consistent logging.
+
+**Independent Test**: Execute `yarn start broadcast release-alerts "Deploying now" --config ./channels.yaml --verbose` and confirm each reported channel send includes the configured identity metadata.
+
+### Tests for User Story 2
+
+- [ ] T017 [US2] Add broadcast identity expectations to `tests/integration/cli-identity-flows.test.ts`, covering multi-channel consistency.
+
+### Implementation for User Story 2
+
+- [ ] T018 [US2] Update `src/commands/broadcast-message.command.ts` to resolve and apply sender identity for each delivery, including verbose provenance logs.
+- [ ] T019 [US2] Ensure broadcast result aggregation in `src/services/broadcast-dry-run.service.ts` and related helpers preserves sender identity metadata.
+- [ ] T020 [US2] Expose identity-aware delivery summaries in `src/services/logging.service.ts` so broadcast verbose output lists the applied identity.
+
+**Checkpoint**: Broadcasts send consistent sender identity across channel lists with clear operator feedback.
+
+---
+
+## Phase 5: User Story 3 - Override fallback handling (Priority: P3)
+
+**Goal**: Prompt operators about incomplete identity data, support overrides, and document fallback provenance.
+
+**Independent Test**: Remove the icon from configuration, run `yarn start send-message C1234567890 "Test" --config ./channels.yaml` interactively to confirm fallback prompt, then rerun with `--allow-default-identity` to verify non-interactive consent.
+
+### Tests for User Story 3
+
+- [ ] T021 [P] [US3] Add prompt consent unit tests covering TTY and non-TTY flows in `tests/unit/utils/prompt.service.test.ts`.
+- [ ] T022 [US3] Extend `tests/unit/commands/send-message.command.test.ts` to assert fallback confirmation and CLI override precedence.
+- [ ] T023 [US3] Add non-interactive pipeline coverage to `tests/integration/cli-identity-flows.test.ts` for `--allow-default-identity` behaviour.
+
+### Implementation for User Story 3
+
+- [ ] T024 [P] [US3] Create `src/utils/prompt.service.ts` providing TTY-aware confirmation prompts with injectable adapters for tests.
+- [ ] T025 [US3] Extend `src/models/command-line-options.ts` with sender override getters and the `allowDefaultIdentity` consent flag.
+- [ ] T026 [US3] Register new CLI flags (`--sender-name`, `--sender-icon-emoji`, `--sender-icon-url`, `--allow-default-identity`) in `src/services/cli.service.ts` and plumb them into `CommandLineOptions` construction.
+- [ ] T027 [US3] Enhance `src/services/identity-resolution.service.ts` to prioritize CLI overrides, request confirmation via PromptService when identity is incomplete, and emit warnings when falling back.
+- [ ] T028 [US3] Update `src/commands/send-message.command.ts` and `src/commands/broadcast-message.command.ts` to use PromptService for fallback consent and respect `--allow-default-identity` in non-interactive runs.
+- [ ] T029 [US3] Surface identity provenance and fallback warnings in verbose output via `src/services/logging.service.ts` and delivery summaries.
+
+**Checkpoint**: Operators must explicitly confirm or override identity fallbacks, with automation-friendly flags available.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finalize documentation, schemas, and developer experience for the identity workflow.
+
+- [ ] T030 Refresh schema documentation in `specs/006-config-post-identity/contracts/sender-identity.schema.yaml` to reflect final implementation nuances.
+- [ ] T031 Update `README.md` quickstart instructions with sender identity configuration and CLI override guidance.
+- [ ] T032 [P] Add regression fixtures for missing identity scenarios in `tests/fixtures/` to support future testing.
+- [ ] T033 Perform end-to-end validation of identity workflows via `tests/integration/cli-identity-flows.test.ts` and update snapshots/log expectations.
+- [ ] T034 Conduct final lint/test run (`npm test && npm run lint`) and summarize results in release notes or changelog entry if applicable.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 → Phase 2**: Foundational work requires shared fixtures to exist.
+- **Phase 2 → Phase 3**: User Story 1 depends on identity models, parsing, and validation.
+- **Phase 3 → Phase 4**: Broadcast identity relies on send-message identity resolution patterns being available.
+- **Phase 4 → Phase 5**: Fallback handling builds atop shared identity workflows established for send and broadcast.
+- **Phase 5 → Phase 6**: Polish tasks complete after all user stories are functional.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Unblocked after Phase 2; establishes baseline identity handling.
+- **US2 (P2)**: Depends on US1’s identity resolution service and Slack service enhancements.
+- **US3 (P3)**: Depends on US1 and US2 for identity plumbing before layering override and consent mechanics.
+
+### Within Each User Story
+
+- Write or update tests before implementing corresponding production changes.
+- Implement services/utilities before integrating them into commands and logging.
+- Verify verbose/audit metadata after Slack service enhancements are in place.
+
+### Parallel Opportunities
+
+- Tasks marked [P] operate on distinct files or pure test additions and can proceed concurrently.
+- Separate contributors can tackle send-message (US1) and broadcast (US2) flows once foundational work is complete.
+- Prompt service development (T024) can happen in parallel with CLI flag wiring (T026) after US1 stabilizes.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Parallelizable tasks once foundational types exist
+# Developer A: identity resolution service implementation
+Task: "T012 [P] [US1] Implement src/services/identity-resolution.service.ts"
+
+# Developer B: identity resolution tests
+Task: "T010 [P] [US1] Add identity resolution unit coverage to tests/unit/services/identity-resolution.service.test.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phases 1 and 2 to load and validate sender identity.
+2. Deliver Phase 3 so `send-message` uses configured identity with provenance logging.
+3. Run targeted unit tests and a manual send to confirm MVP behaviour.
+
+### Incremental Delivery
+
+1. Ship MVP (US1) with config-driven identity for single sends.
+2. Layer US2 to extend identity to broadcasts without regressing single-channel sends.
+3. Add US3 to enforce overrides and fallback consent for robustness.
+4. Finish with Phase 6 polish tasks, documentation, and regression coverage.
+
+### Parallel Team Strategy
+
+- After Phase 2, assign US1 core logic and tests to one developer while another preps broadcast adaptations (US2) awaiting shared services.
+- A third developer can build PromptService (T024) and CLI overrides (T026) in parallel, coordinating with US1 owner for integration points once initial identity resolution lands.
+
+---
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -255,6 +255,10 @@ async function executeBroadcastCommand(
       messageFile: options.messageFile
         ? options.messageFile.toString()
         : undefined,
+      senderName: options.senderName,
+      senderIconEmoji: options.senderIconEmoji,
+      senderIconUrl: options.senderIconUrl,
+      allowDefaultIdentity: options.allowDefaultIdentity,
     }
     if (options.token) {
       broadcastOptions.token = options.token.toString()

--- a/src/main.ts
+++ b/src/main.ts
@@ -252,13 +252,19 @@ async function executeBroadcastCommand(
       message: (options.message || '').toString(),
       dryRun: !!options.dryRun,
       verbose: !!options.verbose,
-      messageFile: options.messageFile
-        ? options.messageFile.toString()
-        : undefined,
-      senderName: options.senderName,
-      senderIconEmoji: options.senderIconEmoji,
-      senderIconUrl: options.senderIconUrl,
-      allowDefaultIdentity: options.allowDefaultIdentity,
+      allowDefaultIdentity: !!options.allowDefaultIdentity,
+    }
+    if (options.messageFile) {
+      broadcastOptions.messageFile = options.messageFile.toString()
+    }
+    if (options.senderName !== undefined) {
+      broadcastOptions.senderName = options.senderName
+    }
+    if (options.senderIconEmoji !== undefined) {
+      broadcastOptions.senderIconEmoji = options.senderIconEmoji
+    }
+    if (options.senderIconUrl !== undefined) {
+      broadcastOptions.senderIconUrl = options.senderIconUrl
     }
     if (options.token) {
       broadcastOptions.token = options.token.toString()

--- a/src/models/broadcast-options.ts
+++ b/src/models/broadcast-options.ts
@@ -19,6 +19,18 @@ export interface BroadcastOptions {
 
   /** Slack API token override */
   token?: string
+
+  /** Optional sender name override */
+  senderName?: string
+
+  /** Optional sender icon emoji override */
+  senderIconEmoji?: string
+
+  /** Optional sender icon URL override */
+  senderIconUrl?: string
+
+  /** Allow default identity usage when configuration lacks sender identity */
+  allowDefaultIdentity?: boolean
 }
 
 /**

--- a/src/models/channel-configuration.ts
+++ b/src/models/channel-configuration.ts
@@ -1,5 +1,6 @@
 import type { NamedChannelList } from './named-channel-list'
 import type { MentionMapping } from './mention-mapping'
+import type { SenderIdentityConfig } from './sender-identity'
 
 /**
  * Configuration structure representing the complete YAML configuration file
@@ -10,6 +11,9 @@ export interface ChannelConfiguration {
 
   /** Optional global mentions mapping */
   mentions?: MentionMapping | undefined
+
+  /** Optional sender identity configuration */
+  senderIdentity?: SenderIdentityConfig | undefined
 
   /** Path to the configuration file */
   filePath: string

--- a/src/models/command-line-options.ts
+++ b/src/models/command-line-options.ts
@@ -36,6 +36,10 @@ export interface CommandLineOptionsParams {
   logLevel?: string | undefined
   timeout?: number | undefined
   retries?: number | undefined
+  senderName?: string | undefined
+  senderIconEmoji?: string | undefined
+  senderIconUrl?: string | undefined
+  allowDefaultIdentity?: boolean | undefined
   // Broadcast command options
   configPath?: string | undefined
   channelList?: string | undefined
@@ -58,6 +62,10 @@ export class CommandLineOptions {
   private readonly _logLevel: string | undefined
   private readonly _timeout: number
   private readonly _retries: number
+  private readonly _senderName: string | undefined
+  private readonly _senderIconEmoji: string | undefined
+  private readonly _senderIconUrl: string | undefined
+  private readonly _allowDefaultIdentity: boolean
   // Broadcast command properties
   private readonly _configPath: string | undefined
   private readonly _channelList: string | undefined
@@ -81,6 +89,10 @@ export class CommandLineOptions {
     this._logLevel = params.logLevel
     this._timeout = params.timeout || 10000 // 10 second default
     this._retries = params.retries || 3 // 3 retries default
+    this._senderName = params.senderName
+    this._senderIconEmoji = params.senderIconEmoji
+    this._senderIconUrl = params.senderIconUrl
+    this._allowDefaultIdentity = params.allowDefaultIdentity || false
     // Broadcast options
     this._configPath = params.configPath
     this._channelList = params.channelList
@@ -166,6 +178,34 @@ export class CommandLineOptions {
    */
   get retries(): number {
     return this._retries
+  }
+
+  /**
+   * Get the sender name override if provided
+   */
+  get senderName(): string | undefined {
+    return this._senderName
+  }
+
+  /**
+   * Get the sender icon emoji override if provided
+   */
+  get senderIconEmoji(): string | undefined {
+    return this._senderIconEmoji
+  }
+
+  /**
+   * Get the sender icon URL override if provided
+   */
+  get senderIconUrl(): string | undefined {
+    return this._senderIconUrl
+  }
+
+  /**
+   * Determine if default identity usage has been explicitly allowed
+   */
+  get allowDefaultIdentity(): boolean {
+    return this._allowDefaultIdentity
   }
 
   /**
@@ -398,6 +438,31 @@ export class CommandLineOptions {
       }
     }
 
+    if (this._senderName !== undefined) {
+      const trimmed = this._senderName?.trim()
+      if (!trimmed) {
+        errors.push('Sender name override must be a non-empty string')
+      }
+    }
+
+    if (this._senderIconEmoji && this._senderIconUrl) {
+      errors.push('Specify either --sender-icon-emoji or --sender-icon-url, not both')
+    }
+
+    if (this._senderIconEmoji) {
+      const trimmed = this._senderIconEmoji.trim()
+      if (!/^:[^:\s]+:$/.test(trimmed)) {
+        errors.push('Sender icon emoji must be in :shortcode: format (e.g., :rocket:)')
+      }
+    }
+
+    if (this._senderIconUrl) {
+      const trimmed = this._senderIconUrl.trim()
+      if (!/^https:\/\//i.test(trimmed)) {
+        errors.push('Sender icon URL must be an https:// URL')
+      }
+    }
+
     if (this._timeout < 1000) {
       errors.push('Timeout must be at least 1000ms (1 second)')
     }
@@ -528,6 +593,10 @@ export class CommandLineOptions {
     logLevel?: string | undefined
     timeout?: number | undefined
     retries?: number | undefined
+    senderName?: string | undefined
+    senderIconEmoji?: string | undefined
+    senderIconUrl?: string | undefined
+    allowDefaultIdentity?: boolean | undefined
     // Broadcast options
     configPath?: string | undefined
     channelList?: string | undefined
@@ -549,6 +618,10 @@ export class CommandLineOptions {
       logLevel: args.logLevel,
       timeout: args.timeout,
       retries: args.retries,
+      senderName: args.senderName,
+      senderIconEmoji: args.senderIconEmoji,
+      senderIconUrl: args.senderIconUrl,
+      allowDefaultIdentity: args.allowDefaultIdentity,
       // Broadcast options
       configPath: args.configPath,
       channelList: args.channelList,
@@ -594,6 +667,10 @@ export class CommandLineOptions {
       logLevel: this._logLevel,
       timeout: this._timeout,
       retries: this._retries,
+      senderName: this._senderName,
+      senderIconEmoji: this._senderIconEmoji,
+      senderIconUrl: this._senderIconUrl,
+      allowDefaultIdentity: this._allowDefaultIdentity,
       isSendMessageCommand: this.isSendMessageCommand,
       isInformationalCommand: this.isInformationalCommand,
       hasRequiredSendMessageArgs: this.hasRequiredSendMessageArgs,

--- a/src/models/sender-identity.ts
+++ b/src/models/sender-identity.ts
@@ -72,13 +72,13 @@ export class SenderIdentity {
       if (trimmedOverrides.iconEmoji !== undefined) {
         merged.iconEmoji = trimmedOverrides.iconEmoji
         if (trimmedOverrides.iconEmoji) {
-          merged.iconUrl = undefined
+          delete merged.iconUrl
         }
       }
       if (trimmedOverrides.iconUrl !== undefined) {
         merged.iconUrl = trimmedOverrides.iconUrl
         if (trimmedOverrides.iconUrl) {
-          merged.iconEmoji = undefined
+          delete merged.iconEmoji
         }
       }
       if (
@@ -101,13 +101,15 @@ export class SenderIdentity {
       source = 'config'
     }
 
+    const identityPayload: ResolvedSenderIdentity = {
+      source,
+      ...(merged.name ? { name: merged.name } : {}),
+      ...(merged.iconEmoji ? { iconEmoji: merged.iconEmoji } : {}),
+      ...(merged.iconUrl ? { iconUrl: merged.iconUrl } : {}),
+    }
+
     return {
-      identity: {
-        name: merged.name,
-        iconEmoji: merged.iconEmoji,
-        iconUrl: merged.iconUrl,
-        source,
-      },
+      identity: identityPayload,
       warnings,
       sourceDescription: source === 'cli' ? 'CLI overrides' : 'configuration',
     }
@@ -149,13 +151,13 @@ export class SenderIdentity {
     const iconUrl = SenderIdentity.normalizeString(overrides.iconUrl)
 
     const result: SenderIdentityOverrides = {}
-    if (overrides.name !== undefined) {
+    if (name !== undefined) {
       result.name = name
     }
-    if (overrides.iconEmoji !== undefined) {
+    if (iconEmoji !== undefined) {
       result.iconEmoji = iconEmoji
     }
-    if (overrides.iconUrl !== undefined) {
+    if (iconUrl !== undefined) {
       result.iconUrl = iconUrl
     }
 

--- a/src/models/sender-identity.ts
+++ b/src/models/sender-identity.ts
@@ -1,0 +1,178 @@
+/**
+ * Sender Identity Models
+ *
+ * Represents the configured and resolved sender identity that can be applied
+ * to Slack messages. The identity consists of a display name plus either an
+ * emoji icon or image URL.
+ */
+
+export type SenderIdentitySource = 'config' | 'cli'
+
+/**
+ * Raw sender identity as defined in configuration files.
+ */
+export interface SenderIdentityConfig {
+  name?: string | null
+  iconEmoji?: string | null
+  iconUrl?: string | null
+  allowDefaultIdentity?: boolean | null
+}
+
+/**
+ * Runtime overrides coming from CLI flags.
+ */
+export interface SenderIdentityOverrides {
+  name?: string | undefined
+  iconEmoji?: string | undefined
+  iconUrl?: string | undefined
+}
+
+/**
+ * Resolved sender identity that will be applied to Slack API requests.
+ */
+export interface ResolvedSenderIdentity {
+  name?: string
+  iconEmoji?: string
+  iconUrl?: string
+  source: SenderIdentitySource
+}
+
+/**
+ * Result of merging configuration and overrides.
+ */
+export interface SenderIdentityResolution {
+  identity?: ResolvedSenderIdentity
+  warnings: string[]
+  sourceDescription?: string
+}
+
+/**
+ * Utility helpers for resolving sender identity information.
+ */
+export class SenderIdentity {
+  /**
+   * Merge configuration identity with CLI overrides.
+   */
+  static resolve(
+    configIdentity?: SenderIdentityConfig,
+    overrides?: SenderIdentityOverrides
+  ): SenderIdentityResolution {
+    const warnings: string[] = []
+
+    const trimmedConfig = SenderIdentity.trimIdentity(configIdentity)
+    const trimmedOverrides = SenderIdentity.trimOverrides(overrides)
+
+    const merged = { ...trimmedConfig }
+    let source: SenderIdentitySource | undefined
+
+    if (trimmedOverrides) {
+      if (trimmedOverrides.name !== undefined) {
+        merged.name = trimmedOverrides.name
+      }
+      if (trimmedOverrides.iconEmoji !== undefined) {
+        merged.iconEmoji = trimmedOverrides.iconEmoji
+        if (trimmedOverrides.iconEmoji) {
+          merged.iconUrl = undefined
+        }
+      }
+      if (trimmedOverrides.iconUrl !== undefined) {
+        merged.iconUrl = trimmedOverrides.iconUrl
+        if (trimmedOverrides.iconUrl) {
+          merged.iconEmoji = undefined
+        }
+      }
+      if (
+        trimmedOverrides.name !== undefined ||
+        trimmedOverrides.iconEmoji !== undefined ||
+        trimmedOverrides.iconUrl !== undefined
+      ) {
+        source = 'cli'
+      }
+    }
+
+    const hasName = !!merged.name
+    const hasIcon = !!merged.iconEmoji || !!merged.iconUrl
+
+    if (!hasName && !hasIcon) {
+      return { warnings }
+    }
+
+    if (!source) {
+      source = 'config'
+    }
+
+    return {
+      identity: {
+        name: merged.name,
+        iconEmoji: merged.iconEmoji,
+        iconUrl: merged.iconUrl,
+        source,
+      },
+      warnings,
+      sourceDescription: source === 'cli' ? 'CLI overrides' : 'configuration',
+    }
+  }
+
+  /**
+   * Check if a resolved identity is complete (has name and icon).
+   */
+  static isComplete(identity?: ResolvedSenderIdentity | null): boolean {
+    if (!identity) return false
+    return !!identity.name && (!!identity.iconEmoji || !!identity.iconUrl)
+  }
+
+  private static trimIdentity(
+    identity?: SenderIdentityConfig
+  ): SenderIdentityConfig {
+    if (!identity) {
+      return {}
+    }
+
+    const name = SenderIdentity.normalizeString(identity.name)
+    const iconEmoji = SenderIdentity.normalizeString(identity.iconEmoji)
+    const iconUrl = SenderIdentity.normalizeString(identity.iconUrl)
+
+    const result: SenderIdentityConfig = {}
+    if (name) result.name = name
+    if (iconEmoji) result.iconEmoji = iconEmoji
+    if (iconUrl) result.iconUrl = iconUrl
+    return result
+  }
+
+  private static trimOverrides(
+    overrides?: SenderIdentityOverrides
+  ): SenderIdentityOverrides | undefined {
+    if (!overrides) return undefined
+
+    const name = SenderIdentity.normalizeString(overrides.name)
+    const iconEmoji = SenderIdentity.normalizeString(overrides.iconEmoji)
+    const iconUrl = SenderIdentity.normalizeString(overrides.iconUrl)
+
+    const result: SenderIdentityOverrides = {}
+    if (overrides.name !== undefined) {
+      result.name = name
+    }
+    if (overrides.iconEmoji !== undefined) {
+      result.iconEmoji = iconEmoji
+    }
+    if (overrides.iconUrl !== undefined) {
+      result.iconUrl = iconUrl
+    }
+
+    if (
+      result.name !== undefined ||
+      result.iconEmoji !== undefined ||
+      result.iconUrl !== undefined
+    ) {
+      return result
+    }
+
+    return undefined
+  }
+
+  private static normalizeString(value?: string | null): string | undefined {
+    if (typeof value !== 'string') return undefined
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : undefined
+  }
+}

--- a/src/services/cli.service.ts
+++ b/src/services/cli.service.ts
@@ -35,6 +35,10 @@ export interface ParsedCliArgs {
   logLevel?: string | undefined
   timeout?: number | undefined
   retries?: number | undefined
+  senderName?: string | undefined
+  senderIconEmoji?: string | undefined
+  senderIconUrl?: string | undefined
+  allowDefaultIdentity?: boolean | undefined
   // Broadcast command options
   configPath?: string | undefined
   channelList?: string | undefined
@@ -106,6 +110,21 @@ export class CliService {
         )
         .option('--timeout <ms>', 'Timeout in milliseconds', '10000')
         .option('--retries <count>', 'Number of retry attempts', '3')
+        .option('-c, --config <path>', 'Path to YAML configuration file for sender identity')
+        .option('--sender-name <name>', 'Override sender display name')
+        .option(
+          '--sender-icon-emoji <emoji>',
+          'Override sender icon emoji (e.g., :rocket:)'
+        )
+        .option(
+          '--sender-icon-url <url>',
+          'Override sender icon URL (https://...)'
+        )
+        .option(
+          '--allow-default-identity',
+          'Allow using the default Slack identity when configuration lacks sender identity',
+          false
+        )
         .action((channelId, messageParts, options) => {
           executedCommand = 'send-message'
           const joined = Array.isArray(messageParts)
@@ -154,6 +173,20 @@ export class CliService {
         .option(
           '--dry-run',
           'Show what would be sent without actually sending',
+          false
+        )
+        .option('--sender-name <name>', 'Override sender display name for this run')
+        .option(
+          '--sender-icon-emoji <emoji>',
+          'Override sender icon emoji (e.g., :rocket:)' 
+        )
+        .option(
+          '--sender-icon-url <url>',
+          'Override sender icon URL (https://...)'
+        )
+        .option(
+          '--allow-default-identity',
+          'Allow using the default Slack identity when configuration lacks sender identity',
           false
         )
         .action((channelList, messageParts, options) => {
@@ -312,6 +345,15 @@ export class CliService {
           : globalOptions['retries']
             ? parseInt(globalOptions['retries'] as string, 10)
             : undefined,
+        senderName: (commandOptions['senderName'] || globalOptions['senderName']) as
+          | string
+          | undefined,
+        senderIconEmoji: (commandOptions['senderIconEmoji'] ||
+          globalOptions['senderIconEmoji']) as string | undefined,
+        senderIconUrl: (commandOptions['senderIconUrl'] ||
+          globalOptions['senderIconUrl']) as string | undefined,
+        allowDefaultIdentity: (commandOptions['allowDefaultIdentity'] ??
+          globalOptions['allowDefaultIdentity']) as boolean | undefined,
         // Broadcast command options
         configPath: (commandOptions['config'] || globalOptions['config']) as
           | string
@@ -357,6 +399,10 @@ export class CliService {
         logLevel: parsedArgs.logLevel || undefined,
         timeout: parsedArgs.timeout || undefined,
         retries: parsedArgs.retries || undefined,
+        senderName: parsedArgs.senderName || undefined,
+        senderIconEmoji: parsedArgs.senderIconEmoji || undefined,
+        senderIconUrl: parsedArgs.senderIconUrl || undefined,
+        allowDefaultIdentity: parsedArgs.allowDefaultIdentity || undefined,
         // Broadcast options
         configPath: parsedArgs.configPath || undefined,
         channelList: parsedArgs.channelList || undefined,

--- a/src/services/slack.service.ts
+++ b/src/services/slack.service.ts
@@ -17,7 +17,10 @@ import { AuthenticationCredentials } from '../models/authentication-credentials.
 import { MessageDeliveryResult } from '../models/message-delivery-result.js'
 import type { ResolvedChannel } from '../models/resolved-channel'
 import type { BroadcastResult } from '../models/broadcast-result'
-import type { ChannelDeliveryResult } from '../models/channel-delivery-result'
+import type {
+  ChannelDeliveryResult,
+  SlackError,
+} from '../models/channel-delivery-result'
 import type { BroadcastOptions } from '../models/broadcast-options'
 import type { ResolvedSenderIdentity } from '../models/sender-identity'
 
@@ -66,13 +69,8 @@ export class SlackService {
       }
 
       // Prepare the API call
-      const response = await this.performSendMessage(
-        message,
-        target,
-        identity
-      )
+      const response = await this.performSendMessage(message, target, identity)
       const deliveryTime = Date.now() - startTime
-
       // Process successful response
       if (response.ok && response.message) {
         return MessageDeliveryResult.success({
@@ -101,12 +99,17 @@ export class SlackService {
       } else {
         // Handle API error response
         const error = new Error(response.error || 'Unknown Slack API error')
+        const metadata: Record<string, unknown> = {
+          slackResponse: response,
+        }
+
         return this.createFailureResult(
           error,
           target.identifier,
           Date.now() - startTime,
           retryCount,
-          identity
+          identity,
+          metadata
         )
       }
     } catch (error) {
@@ -207,33 +210,34 @@ export class SlackService {
 
     if (identity && identity.name) {
       payload['username'] = identity.name
-      payload['as_user'] = false
       if (identity.iconEmoji) {
         payload['icon_emoji'] = identity.iconEmoji
       }
       if (identity.iconUrl) {
         payload['icon_url'] = identity.iconUrl
       }
-    } else {
-      payload['as_user'] = true
     }
 
     return await this.client.chat.postMessage(payload)
   }
 
-  /**
-   * Create a failure result based on error type
-   */
   private createFailureResult(
     error: Error,
     channelId: string,
     deliveryTimeMs: number,
     retryCount: number,
-    identity?: ResolvedSenderIdentity
+    identity?: ResolvedSenderIdentity,
+    extraMetadata?: Record<string, unknown>
   ): MessageDeliveryResult {
+    let normalizedError = error
+
     const metadata: Record<string, unknown> = {
-      originalError: error.name,
       deliveryAttempts: retryCount + 1,
+      deliveryTimeMs,
+      retryCount,
+      originalError: error.name,
+      originalErrorMessage: error.message,
+      ...(extraMetadata ?? {}),
     }
 
     if (identity) {
@@ -245,27 +249,111 @@ export class SlackService {
       }
     }
 
-    // Determine error type and create appropriate result
-    if (this.isAuthenticationError(error)) {
-      return MessageDeliveryResult.authenticationError(error, metadata)
-    } else if (this.isChannelError(error)) {
-      return MessageDeliveryResult.channelError(error, channelId, metadata)
-    } else if (this.isNetworkError(error)) {
+    const slackResponse = this.extractSlackResponse(normalizedError, metadata)
+    if (slackResponse && !metadata['slackResponse']) {
+      metadata['slackResponse'] = slackResponse
+    }
+
+    const slackError = this.extractSlackErrorCode(normalizedError, metadata)
+    if (slackError) {
+      metadata['slackError'] = slackError
+    }
+
+    if (this.isInvalidArgumentsError(normalizedError, metadata)) {
+      const message = this.buildInvalidArgumentsMessage(
+        normalizedError,
+        metadata
+      )
+      const validationError = new Error(message)
+      validationError.name = 'ValidationError'
+      normalizedError = validationError
+      metadata['errorCategory'] = 'invalid_arguments'
+      metadata['validationGuidance'] =
+        'Ensure the message text is between 1 and 40,000 characters, is not empty, and the channel ID is valid.'
+    }
+
+    if (this.isAuthenticationError(normalizedError)) {
+      return MessageDeliveryResult.authenticationError(
+        normalizedError,
+        metadata
+      )
+    }
+
+    if (this.isChannelError(normalizedError)) {
+      return MessageDeliveryResult.channelError(
+        normalizedError,
+        channelId,
+        metadata
+      )
+    }
+
+    if (this.isNetworkError(normalizedError)) {
       return MessageDeliveryResult.networkError(
-        error,
+        normalizedError,
         channelId,
         retryCount,
         metadata
       )
-    } else {
-      return MessageDeliveryResult.failure({
-        error,
-        channelId,
-        deliveryTimeMs,
-        retryCount,
-        metadata,
-      })
     }
+
+    return MessageDeliveryResult.failure({
+      error: normalizedError,
+      channelId,
+      deliveryTimeMs,
+      retryCount,
+      metadata,
+    })
+  }
+
+  private extractSlackResponse(
+    error: Error,
+    metadata: Record<string, unknown>
+  ): ChatPostMessageResponse | undefined {
+    const fromMetadata = metadata['slackResponse']
+    if (fromMetadata && typeof fromMetadata === 'object') {
+      return fromMetadata as ChatPostMessageResponse
+    }
+
+    const errorWithData = error as Error & {
+      data?: Partial<ChatPostMessageResponse>
+    }
+
+    if (
+      errorWithData.data &&
+      typeof errorWithData.data === 'object' &&
+      errorWithData.data.ok === false
+    ) {
+      return errorWithData.data as ChatPostMessageResponse
+    }
+
+    return undefined
+  }
+
+  private extractSlackErrorCode(
+    error: Error,
+    metadata: Record<string, unknown>
+  ): string | undefined {
+    const fromMetadata = metadata['slackError']
+    if (typeof fromMetadata === 'string' && fromMetadata.length > 0) {
+      return fromMetadata
+    }
+
+    const slackResponse = metadata['slackResponse'] as
+      | ChatPostMessageResponse
+      | undefined
+    if (slackResponse?.error) {
+      return slackResponse.error
+    }
+
+    const errorWithData = error as Error & {
+      data?: { error?: unknown }
+    }
+
+    if (errorWithData.data && typeof errorWithData.data.error === 'string') {
+      return errorWithData.data.error
+    }
+
+    return undefined
   }
 
   /**
@@ -322,6 +410,62 @@ export class SlackService {
     return networkErrorPatterns.some(
       pattern => pattern.test(error.message) || pattern.test(error.name)
     )
+  }
+
+  private isInvalidArgumentsError(
+    error: Error,
+    extraMetadata?: Record<string, unknown>
+  ): boolean {
+    const patterns = [
+      /invalid_arguments/i,
+      /text.*must.*not.*be.*empty/i,
+      /text.*cannot.*be.*empty/i,
+      /invalid.*arguments/i,
+    ]
+
+    const matchesPattern = patterns.some(
+      pattern => pattern.test(error.message) || pattern.test(error.name)
+    )
+
+    if (matchesPattern) {
+      return true
+    }
+
+    const slackResponse = extraMetadata?.['slackResponse'] as
+      | ChatPostMessageResponse
+      | undefined
+    const responseMessages = slackResponse?.response_metadata?.messages
+    if (Array.isArray(responseMessages)) {
+      return responseMessages.some(message =>
+        patterns.some(pattern => pattern.test(message))
+      )
+    }
+
+    return false
+  }
+
+  private buildInvalidArgumentsMessage(
+    error: Error,
+    extraMetadata?: Record<string, unknown>
+  ): string {
+    const slackResponse = extraMetadata?.['slackResponse'] as
+      | ChatPostMessageResponse
+      | undefined
+    const responseMessages = slackResponse?.response_metadata?.messages
+
+    const guidance =
+      'Ensure the message text is between 1 and 40,000 characters, is not empty, and the channel ID is valid.'
+
+    if (Array.isArray(responseMessages) && responseMessages.length > 0) {
+      const combined = responseMessages.join(' ')
+      return `Slack rejected the request: ${combined}`
+    }
+
+    if (error.message && error.message !== 'invalid_arguments') {
+      return `Slack rejected the request: ${error.message}`
+    }
+
+    return `Slack rejected the request due to invalid arguments. ${guidance}`
   }
 
   /**
@@ -486,35 +630,8 @@ export class SlackService {
   ): Promise<BroadcastResult> {
     const deliveryResults: ChannelDeliveryResult[] = []
 
-    for (const channel of channels) {
+    for (const [index, channel] of channels.entries()) {
       try {
-        // Skip if bot is not a member and it's a private channel
-        if (channel.isPrivate && !channel.isMember) {
-          deliveryResults.push({
-            channel,
-            status: 'skipped',
-            error: {
-              type: 'not_in_channel',
-              message: 'Bot is not a member of this private channel',
-            },
-          })
-          continue
-        }
-
-        // Skip archived channels
-        if (channel.isArchived) {
-          deliveryResults.push({
-            channel,
-            status: 'failed',
-            error: {
-              type: 'is_archived',
-              message: 'Cannot send messages to archived channels',
-            },
-          })
-          continue
-        }
-
-        // Send message
         const payload: ChatPostMessageArguments = {
           channel: channel.id,
           text: message,
@@ -523,20 +640,16 @@ export class SlackService {
         }
 
         if (identity && identity.name) {
-          payload.username = identity.name
-          payload.as_user = false
+          payload['username'] = identity.name
           if (identity.iconEmoji) {
-            payload.icon_emoji = identity.iconEmoji
+            payload['icon_emoji'] = identity.iconEmoji
           }
           if (identity.iconUrl) {
-            payload.icon_url = identity.iconUrl
+            payload['icon_url'] = identity.iconUrl
           }
-        } else {
-          payload.as_user = true
         }
 
         const response = await this.client.chat.postMessage(payload)
-
         if (response.ok && response.ts) {
           deliveryResults.push({
             channel,
@@ -545,51 +658,314 @@ export class SlackService {
             deliveredAt: new Date(),
           })
         } else {
-          deliveryResults.push({
-            channel,
-            status: 'failed',
-            error: {
-              type: response.error || 'unknown_error',
-              message: response.error || 'Unknown error occurred',
-            },
-          })
+          const errorMessage =
+            response.error || 'Slack API returned an unsuccessful response'
+          const apiError = new Error(errorMessage)
+          deliveryResults.push(
+            this.buildChannelFailureResult(channel, apiError, response)
+          )
         }
-
-        // Small delay to respect rate limits
-        await new Promise(resolve => setTimeout(resolve, 100))
       } catch (error) {
-        deliveryResults.push({
-          channel,
-          status: 'failed',
-          error: {
-            type: 'network_error',
-            message: error instanceof Error ? error.message : String(error),
-          },
-        })
+        const normalizedError =
+          error instanceof Error ? error : new Error(String(error))
+        deliveryResults.push(
+          this.buildChannelFailureResult(channel, normalizedError)
+        )
       }
-    }
 
-    // Determine overall status
-    const successCount = deliveryResults.filter(
-      r => r.status === 'success'
-    ).length
-
-    let overallStatus: 'success' | 'partial' | 'failed'
-    if (successCount === channels.length) {
-      overallStatus = 'success'
-    } else if (successCount > 0) {
-      overallStatus = 'partial'
-    } else {
-      overallStatus = 'failed'
+      if (index < channels.length - 1) {
+        await this.delay(100)
+      }
     }
 
     return {
       targetListName: options?.listName || 'unknown',
       totalChannels: channels.length,
       deliveryResults,
-      overallStatus,
+      overallStatus: this.determineOverallStatus(deliveryResults),
       completedAt: new Date(),
     }
+  }
+
+  private buildChannelFailureResult(
+    channel: ResolvedChannel,
+    error: Error,
+    slackResponse?: ChatPostMessageResponse
+  ): ChannelDeliveryResult {
+    const slackError = this.normalizeSlackError(error, slackResponse)
+    const status: ChannelDeliveryResult['status'] = this.shouldMarkAsSkipped(
+      slackError.type,
+      channel
+    )
+      ? 'skipped'
+      : 'failed'
+
+    return {
+      channel,
+      status,
+      error: slackError,
+    }
+  }
+
+  private normalizeSlackError(
+    error: Error,
+    slackResponse?: ChatPostMessageResponse
+  ): SlackError {
+    const metadata: Record<string, unknown> = {}
+    if (slackResponse) {
+      metadata['slackResponse'] = slackResponse
+    }
+
+    const rawType = this.extractSlackErrorCode(error, metadata)
+    const normalizedType =
+      rawType && `${rawType}`.length > 0
+        ? this.normalizeErrorType(String(rawType))
+        : this.classifyFallbackError(error)
+
+    const fallbackMessage = this.extractErrorMessage(error, slackResponse)
+    const message = this.getSlackErrorMessage(normalizedType, fallbackMessage)
+    const details = this.buildSlackErrorDetails(error, slackResponse)
+    const retryAfter = this.extractRetryAfterSeconds(error)
+
+    const slackError: SlackError = {
+      type: normalizedType,
+      message,
+    }
+
+    if (details && Object.keys(details).length > 0) {
+      slackError.details = details
+    }
+
+    if (typeof retryAfter === 'number' && Number.isFinite(retryAfter)) {
+      slackError.retryAfter = retryAfter
+    }
+
+    return slackError
+  }
+
+  private determineOverallStatus(
+    results: ChannelDeliveryResult[]
+  ): BroadcastResult['overallStatus'] {
+    if (results.length === 0) {
+      return 'success'
+    }
+
+    const successCount = results.filter(r => r.status === 'success').length
+    if (successCount === results.length) {
+      return 'success'
+    }
+
+    if (successCount === 0) {
+      return 'failed'
+    }
+
+    return 'partial'
+  }
+
+  private shouldMarkAsSkipped(
+    errorType: string | undefined,
+    channel: ResolvedChannel
+  ): boolean {
+    if (!errorType) {
+      return false
+    }
+
+    const skipTypes = new Set([
+      'not_in_channel',
+      'not_in_group',
+      'missing_scope',
+      'no_permission',
+      'restricted_action',
+      'cannot_dm_bot',
+    ])
+
+    if (skipTypes.has(errorType)) {
+      return true
+    }
+
+    if (!channel.isMember && errorType === 'channel_error') {
+      return true
+    }
+
+    return false
+  }
+
+  private getSlackErrorMessage(errorType: string, fallback: string): string {
+    const safeFallback =
+      fallback && fallback.trim().length > 0
+        ? fallback
+        : 'Slack API request failed'
+
+    switch (errorType) {
+      case 'not_in_channel':
+      case 'not_in_group':
+        return 'Bot is not a member of the channel.'
+      case 'missing_scope':
+        return 'Missing a required Slack scope for this channel.'
+      case 'no_permission':
+      case 'restricted_action':
+        return 'Slack denied permission to post to this channel.'
+      case 'cannot_dm_bot':
+        return 'Cannot send direct messages to this bot.'
+      case 'channel_is_archived':
+      case 'is_archived':
+        return 'Channel is archived and cannot receive messages.'
+      case 'channel_not_found':
+        return 'Channel not found. Verify the channel ID or name.'
+      case 'invalid_auth':
+      case 'not_authed':
+        return 'Authentication failed for the Slack workspace.'
+      case 'rate_limited':
+        return 'Slack rate limit reached. Try again after waiting.'
+      case 'network_error':
+        return 'Network error while contacting Slack.'
+      default:
+        return safeFallback
+    }
+  }
+
+  private normalizeErrorType(value: string): string {
+    if (!value || value.trim().length === 0) {
+      return 'unknown_error'
+    }
+
+    return value
+      .trim()
+      .replace(/([a-z])([A-Z])/g, '$1_$2')
+      .replace(/[\s-]+/g, '_')
+      .toLowerCase()
+  }
+
+  private classifyFallbackError(error: Error): string {
+    if (this.isAuthenticationError(error)) {
+      return 'authentication_error'
+    }
+
+    if (this.isChannelError(error)) {
+      return 'channel_error'
+    }
+
+    if (this.isNetworkError(error)) {
+      return 'network_error'
+    }
+
+    return error.name && error.name !== 'Error'
+      ? this.normalizeErrorType(error.name)
+      : 'unknown_error'
+  }
+
+  private extractErrorMessage(
+    error: Error,
+    slackResponse?: ChatPostMessageResponse
+  ): string {
+    if (slackResponse?.error) {
+      return slackResponse.error
+    }
+
+    const errorWithData = error as Error & {
+      data?: Record<string, unknown>
+    }
+
+    const data = errorWithData.data
+    const dataError = data?.['error']
+    if (typeof dataError === 'string' && dataError.length > 0) {
+      return dataError
+    }
+
+    const match = /An API error occurred: (.+)$/i.exec(error.message)
+    if (match && match[1]) {
+      return match[1]
+    }
+
+    return error.message || 'Slack API request failed'
+  }
+
+  private buildSlackErrorDetails(
+    error: Error,
+    slackResponse?: ChatPostMessageResponse
+  ): Record<string, unknown> | undefined {
+    const details: Record<string, unknown> = {}
+    const errorWithData = error as Error & {
+      data?: Record<string, unknown>
+    }
+
+    const responseMetadata =
+      slackResponse?.response_metadata ||
+      (errorWithData.data?.['response_metadata'] as
+        | Record<string, unknown>
+        | undefined)
+
+    const messages = responseMetadata?.['messages']
+    if (Array.isArray(messages) && messages.length > 0) {
+      details['slackMessages'] = messages
+    }
+
+    const warnings = responseMetadata?.['warnings']
+    if (Array.isArray(warnings) && warnings.length > 0) {
+      details['warnings'] = warnings
+    }
+
+    if (errorWithData.data) {
+      const needed = errorWithData.data['needed']
+      if (needed !== undefined) {
+        details['needed'] = needed
+      }
+
+      const provided = errorWithData.data['provided']
+      if (provided !== undefined) {
+        details['provided'] = provided
+      }
+
+      const scopes = errorWithData.data['scopes']
+      if (scopes !== undefined) {
+        details['scopes'] = scopes
+      }
+
+      const acceptedScopes = errorWithData.data['acceptedScopes']
+      if (acceptedScopes !== undefined) {
+        details['acceptedScopes'] = acceptedScopes
+      }
+    }
+
+    return Object.keys(details).length > 0 ? details : undefined
+  }
+
+  private extractRetryAfterSeconds(error: Error): number | undefined {
+    const errorWithRetry = error as Error & {
+      retryAfter?: number
+      data?: Record<string, unknown>
+    }
+
+    if (typeof errorWithRetry.retryAfter === 'number') {
+      return errorWithRetry.retryAfter
+    }
+
+    const data = errorWithRetry.data
+    if (data) {
+      const retryAfterValue = data['retry_after']
+      if (typeof retryAfterValue === 'number') {
+        return retryAfterValue
+      }
+
+      const headers = data['headers'] as Record<string, unknown> | undefined
+      if (headers) {
+        const headerValue = headers['retry-after'] ?? headers['Retry-After']
+        if (typeof headerValue === 'string') {
+          const parsed = Number(headerValue)
+          if (Number.isFinite(parsed)) {
+            return parsed
+          }
+        } else if (typeof headerValue === 'number') {
+          return headerValue
+        }
+      }
+    }
+
+    return undefined
+  }
+
+  private async delay(ms: number): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, ms))
   }
 
   /**

--- a/test-config.yml
+++ b/test-config.yml
@@ -1,3 +1,7 @@
+sender_identity:
+  name: 'QA Notifier'
+  icon_emoji: ':loudspeaker:'
+
 channel_lists:
   - name: 'development'
     description: 'Channels for development team'

--- a/tests/unit/mentions-config-validation.test.ts
+++ b/tests/unit/mentions-config-validation.test.ts
@@ -54,3 +54,82 @@ describe('mentions config validation (T026)', () => {
     expect(result.errors.some(e => e.field === 'mentions')).toBe(true)
   })
 })
+
+describe('sender identity validation', () => {
+  const service = new ConfigValidationService()
+
+  it('accepts valid sender identity configuration', () => {
+    const config: ChannelConfiguration = {
+      ...baseConfig(),
+      senderIdentity: {
+        name: 'Deploy Bot',
+        iconEmoji: ':rocket:',
+      },
+    }
+
+    const result = service.validateChannelConfiguration(config)
+    expect(result.isValid).toBe(true)
+  })
+
+  it('rejects missing icon values', () => {
+    const config: ChannelConfiguration = {
+      ...baseConfig(),
+      senderIdentity: {
+        name: 'Deploy Bot',
+      },
+    }
+
+    const result = service.validateChannelConfiguration(config)
+    expect(result.isValid).toBe(false)
+    expect(result.errors.map(e => e.field)).toContain('senderIdentity.icon')
+  })
+
+  it('rejects simultaneous emoji and URL icons', () => {
+    const config: ChannelConfiguration = {
+      ...baseConfig(),
+      senderIdentity: {
+        name: 'Deploy Bot',
+        iconEmoji: ':rocket:',
+        iconUrl: 'https://example.com/icon.png',
+      },
+    }
+
+    const result = service.validateChannelConfiguration(config)
+    expect(result.isValid).toBe(false)
+    expect(result.errors.map(e => e.field)).toContain(
+      'senderIdentity.iconEmoji'
+    )
+  })
+
+  it('rejects invalid icon emoji format', () => {
+    const config: ChannelConfiguration = {
+      ...baseConfig(),
+      senderIdentity: {
+        name: 'Deploy Bot',
+        iconEmoji: 'rocket',
+      },
+    }
+
+    const result = service.validateChannelConfiguration(config)
+    expect(result.isValid).toBe(false)
+    expect(result.errors.map(e => e.field)).toContain(
+      'senderIdentity.iconEmoji'
+    )
+  })
+
+  it('rejects non-https icon URLs', () => {
+    const config: ChannelConfiguration = {
+      ...baseConfig(),
+      senderIdentity: {
+        name: 'Deploy Bot',
+        iconUrl: 'http://example.com/icon.png',
+      },
+    }
+
+    const result = service.validateChannelConfiguration(config)
+    expect(result.isValid).toBe(false)
+    expect(result.errors.map(e => e.field)).toContain(
+      'senderIdentity.iconUrl'
+    )
+  })
+})

--- a/tests/unit/send-message-identity.test.ts
+++ b/tests/unit/send-message-identity.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SendMessageCommand } from '../../src/commands/send-message.command.js'
+import { CommandLineOptions } from '../../src/models/command-line-options.js'
+import type {
+  CommandLineOptionsParams,
+} from '../../src/models/command-line-options.js'
+import type { SlackService } from '../../src/services/slack.service.js'
+import { AppConfig } from '../../src/config/app-config.js'
+import { MessageDeliveryResult } from '../../src/models/message-delivery-result.js'
+import type { ChannelConfiguration } from '../../src/models/channel-configuration.js'
+
+function createSlackServiceMock() {
+  const mocks = {
+    testAuthentication: vi
+      .fn()
+      .mockResolvedValue({ valid: true, botId: 'B123', teamId: 'T123' }),
+    getChannelInfo: vi
+      .fn()
+      .mockResolvedValue({
+        exists: true,
+        name: 'general',
+        isPrivate: false,
+        isMember: true,
+      }),
+    sendMessage: vi
+      .fn()
+      .mockResolvedValue(
+        MessageDeliveryResult.success({
+          messageId: '123.456',
+          timestamp: '123.456',
+          channelId: 'C1234567890',
+        })
+      ),
+    getClientConfig: vi.fn().mockReturnValue({}),
+  }
+
+  return {
+    service: mocks as unknown as SlackService,
+    mocks,
+  }
+}
+
+function createOptions(overrides: Partial<CommandLineOptionsParams> = {}) {
+  return new CommandLineOptions({
+    command: 'send-message',
+    channelId: 'C1234567890',
+    message: 'Hello world',
+    token: 'xoxb-test-token',
+    configPath: '/tmp/channels.yaml',
+    ...overrides,
+  })
+}
+
+describe('SendMessageCommand sender identity gating', () => {
+  let slackService: SlackService
+  let slackServiceMocks: ReturnType<typeof createSlackServiceMock>['mocks']
+  let command: SendMessageCommand
+
+  beforeEach(() => {
+    const mockBundle = createSlackServiceMock()
+    slackService = mockBundle.service
+    slackServiceMocks = mockBundle.mocks
+    command = SendMessageCommand.forTesting({ slackService })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fails when sender identity is missing and fallback not allowed', async () => {
+    const configuration: ChannelConfiguration = {
+      channelLists: [],
+      filePath: '/tmp/channels.yaml',
+    }
+
+    vi.spyOn(AppConfig, 'loadChannelConfiguration').mockResolvedValue({
+      success: true,
+      configuration,
+      resolvedPath: configuration.filePath,
+    })
+
+    const result = await command.execute(createOptions())
+
+    expect(result.success).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect(result.output.some(line => line.includes('--allow-default-identity'))).toBe(true)
+    expect(slackServiceMocks.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('allows default identity when configuration enables allow_default_identity', async () => {
+    const configuration: ChannelConfiguration = {
+      channelLists: [],
+      filePath: '/tmp/channels.yaml',
+      senderIdentity: { allowDefaultIdentity: true },
+    }
+
+    vi.spyOn(AppConfig, 'loadChannelConfiguration').mockResolvedValue({
+      success: true,
+      configuration,
+      resolvedPath: configuration.filePath,
+    })
+
+    const result = await command.execute(createOptions())
+
+    expect(result.success).toBe(true)
+    expect(result.exitCode).toBe(0)
+    expect(result.output.some(line => line.includes('allows using the default Slack identity'))).toBe(true)
+    expect(slackServiceMocks.sendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows default identity when CLI flag is provided', async () => {
+    const configuration: ChannelConfiguration = {
+      channelLists: [],
+      filePath: '/tmp/channels.yaml',
+    }
+
+    vi.spyOn(AppConfig, 'loadChannelConfiguration').mockResolvedValue({
+      success: true,
+      configuration,
+      resolvedPath: configuration.filePath,
+    })
+
+    const result = await command.execute(
+      createOptions({ allowDefaultIdentity: true })
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.exitCode).toBe(0)
+    expect(slackServiceMocks.sendMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/slack-service-invalid-arguments.test.ts
+++ b/tests/unit/slack-service-invalid-arguments.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { SlackService } from '../../src/services/slack.service.js'
+import { AuthenticationCredentials } from '../../src/models/authentication-credentials.js'
+import { SlackMessage } from '../../src/models/slack-message.js'
+import type { ChannelTarget } from '../../src/models/channel-target'
+
+const mockClient = {
+  conversations: {
+    info: vi.fn().mockResolvedValue({
+      ok: true,
+      channel: {
+        id: 'C1234567890',
+        name: 'general',
+        is_private: false,
+        is_member: true,
+      },
+    }),
+  },
+  auth: {
+    test: vi.fn().mockResolvedValue({
+      ok: true,
+      bot_id: 'B123',
+      team_id: 'T123',
+    }),
+  },
+  chat: {
+    postMessage: vi.fn().mockResolvedValue({
+      ok: false,
+      error: 'invalid_arguments',
+      response_metadata: {
+        messages: ['text must not be empty'],
+      },
+    }),
+  },
+}
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn().mockImplementation(() => mockClient),
+  LogLevel: {
+    INFO: 'info',
+    DEBUG: 'debug',
+    ERROR: 'error',
+  },
+}))
+
+describe('SlackService invalid argument handling', () => {
+  let service: SlackService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const credentials = AuthenticationCredentials.forBotToken(
+      'xoxb-valid-test-token'
+    )
+    service = new SlackService({ credentials })
+  })
+
+  it('wraps invalid_arguments responses as validation errors with guidance', async () => {
+    const message = SlackMessage.create('Hello world', 'C1234567890')
+    const target: ChannelTarget = { identifier: 'C1234567890', type: 'id' }
+
+    const result = await service.sendMessage(message, target)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBeDefined()
+    expect(result.error?.name).toBe('ValidationError')
+    expect(result.error?.message).toMatch(/Slack rejected the request/i)
+    expect(result.error?.message).toMatch(/text must not be empty/i)
+    expect(result.exitCode).toBe(1)
+    expect(result.metadata?.errorCategory).toBe('invalid_arguments')
+    expect(result.metadata?.slackError).toBe('invalid_arguments')
+  })
+
+  it('returns validation-rich failures for broadcast invalid_arguments exceptions', async () => {
+    const rejection = Object.assign(
+      new Error('An API error occurred: invalid_arguments'),
+      {
+        data: {
+          ok: false,
+          error: 'invalid_arguments',
+          response_metadata: {
+            messages: ['text must not be empty'] as string[],
+          },
+        },
+      }
+    )
+
+    mockClient.chat.postMessage.mockRejectedValueOnce(rejection)
+
+    const channels = [
+      {
+        id: 'C1234567890',
+        name: 'general',
+        isPrivate: false,
+        isMember: true,
+        isArchived: false,
+      },
+    ]
+
+    const result = await service.broadcastMessage(channels, 'Test message')
+
+    expect(result.deliveryResults[0].error?.type).toBe('invalid_arguments')
+    expect(result.deliveryResults[0].error?.message).toMatch(
+      /Slack rejected the request/i
+    )
+    expect(result.deliveryResults[0].error?.details?.guidance).toMatch(
+      /Ensure the message text/i
+    )
+    expect(result.overallStatus).toBe('failed')
+  })
+})

--- a/tests/unit/yaml-validation.test.ts
+++ b/tests/unit/yaml-validation.test.ts
@@ -36,6 +36,8 @@ describe('YAML Configuration Validation', () => {
         expect(developmentList).toBeDefined()
         expect(developmentList!.channels).toHaveLength(3)
         expect(config.filePath).toBe('./test-config.yml')
+        expect(config.senderIdentity?.name).toBe('QA Notifier')
+        expect(config.senderIdentity?.iconEmoji).toBe(':loudspeaker:')
       })
 
       it('should throw error for invalid YAML syntax', async () => {


### PR DESCRIPTION
## Summary
- block send and broadcast commands when no sender identity is resolved unless the operator explicitly allows the default identity via CLI flag or configuration
- capture sender identity resolution metadata to surface warnings and abort execution when fallback consent is missing
- add unit coverage for send-message flows that require allow_default_identity and ensure Slack calls proceed only when consented

## Testing
- CI=1 npx vitest run tests/unit/send-message-identity.test.ts tests/unit/yaml-validation.test.ts tests/unit/mentions-config-validation.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f8fa56b3988329b9082af001edcfe4